### PR TITLE
#21 - 게시판 정렬 기능 구현

### DIFF
--- a/fastcampus-project-board2/.idea/compiler.xml
+++ b/fastcampus-project-board2/.idea/compiler.xml
@@ -23,7 +23,4 @@
     </annotationProcessing>
     <bytecodeTargetLevel target="17" />
   </component>
-  <component name="JavacSettings">
-    <option name="ADDITIONAL_OPTIONS_STRING" value="-parameters" />
-  </component>
 </project>

--- a/fastcampus-project-board2/src/main/resources/static/css/articles/table-header.css
+++ b/fastcampus-project-board2/src/main/resources/static/css/articles/table-header.css
@@ -1,0 +1,4 @@
+#article-table > thead a {
+    text-decoration: none;
+    color: black;
+}

--- a/fastcampus-project-board2/src/main/resources/templates/articles/index.html
+++ b/fastcampus-project-board2/src/main/resources/templates/articles/index.html
@@ -9,6 +9,7 @@
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
     <link href="/css/search-bar.css" rel="stylesheet">
+    <link href="/css/articles/table-header.css" rel="stylesheet">
 </head>
 
 <body>
@@ -60,10 +61,10 @@
     <table class="table" id="article-table">
         <thead>
         <tr>
-            <th class="title col-6">제목</th>
-            <th class="hashtag col-2">해시태그</th>
-            <th class="user-id col">작성자</th>
-            <th class="created-at col">작성일</th>
+            <th class="title col-6"><a>제목</a></th>
+            <th class="hashtag col-2"><a>해시태그</a></th>
+            <th class="user-id col"><a>작성자</a></th>
+            <th class="created-at col"><a>작성일</a></th>
         </tr>
         </thead>
         <tbody>

--- a/fastcampus-project-board2/src/main/resources/templates/articles/index.th.xml
+++ b/fastcampus-project-board2/src/main/resources/templates/articles/index.th.xml
@@ -3,34 +3,55 @@
     <attr sel="#header" th:replace="header :: header" />
     <attr sel="#footer" th:replace="footer :: footer" />
 
-    <attr sel="#article-table">
-        <attr sel="tbody" th:remove="all-but-first">
-            <attr sel="tr[0]" th:each="article : ${articles}">
-                <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
-                <attr sel="td.hashtag" th:text="${article.hashtag}" />
-                <attr sel="td.user-id" th:text="${article.nickname}" />
-                <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+    <attr sel="main" th:object="${articles}">
+        <attr sel="#article-table">
+            <attr sel="thead/tr">
+                <attr sel="th.title/a" th:text="'제목'" th:href="@{/articles(
+            page=${articles.number},
+            sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : '')
+        )}"/>
+                <attr sel="th.hashtag/a" th:text="'해시태그'" th:href="@{/articles(
+            page=${articles.number},
+            sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : '')
+        )}"/>
+                <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles(
+            page=${articles.number},
+            sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : '')
+        )}"/>
+                <attr sel="th.created-at/a" th:text="'작성일'" th:href="@{/articles(
+            page=${articles.number},
+            sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : '')
+        )}"/>
+            </attr>
+
+            <attr sel="tbody" th:remove="all-but-first">
+                <attr sel="tr[0]" th:each="article : ${articles}">
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
+                    <attr sel="td.hashtag" th:text="${article.hashtag}" />
+                    <attr sel="td.user-id" th:text="${article.nickname}" />
+                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+                </attr>
             </attr>
         </attr>
-    </attr>
 
-    <attr sel="#pagination">
-        <attr sel="li[0]/a"
-              th:text="'<'"
-              th:href="@{/articles(page=${articles.number - 1})}"
-              th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
-        />
-        <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
-            <attr sel="a"
-                  th:text="${pageNumber + 1}"
-                  th:href="@{/articles(page=${pageNumber})}"
-                  th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+        <attr sel="#pagination">
+            <attr sel="li[0]/a"
+                  th:text="'previous'"
+                  th:href="@{/articles(page=${articles.number - 1})}"
+                  th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+            />
+            <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+                <attr sel="a"
+                      th:text="${pageNumber + 1}"
+                      th:href="@{/articles(page=${pageNumber})}"
+                      th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+                />
+            </attr>
+            <attr sel="li[2]/a"
+                  th:text="'next'"
+                  th:href="@{/articles(page=${articles.number + 1})}"
+                  th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
             />
         </attr>
-        <attr sel="li[2]/a"
-              th:text="'>'"
-              th:href="@{/articles(page=${articles.number + 1})}"
-              th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
-        />
     </attr>
 </thlogic>


### PR DESCRIPTION
기존 스프링 부트의 정렬 기능을 이용하여, 이름, 해쉬태그, 작성자, 작성일을 기준으로 정렬할 수 있게 게시판을 구현하였다.